### PR TITLE
fix: add timeout to sales orders details request

### DIFF
--- a/tap_zohobooks/client.py
+++ b/tap_zohobooks/client.py
@@ -40,12 +40,12 @@ class ZohoBooksStream(RESTStream):
     def get_new_paginator(self):
         return ZohoBooksPaginator(start_value=1)
     
-    def _request(self, prepared_request, context={}) -> requests.Response:
+    def _request(self, prepared_request, context={}, timeout=None) -> requests.Response:
         """
         Custom request function to enable us to throtle the requests,
         distributing them equaly during the runtime.
         """
-        response = super()._request(prepared_request, context=context)
+        response = super()._request(prepared_request, context=context,timeout=timeout)
         rate_limit = response.headers.get("X-Rate-Limit-Limit")
         remaining_rate_limit = response.headers.get("X-Rate-Limit-Remaining")
         if rate_limit and remaining_rate_limit:

--- a/tap_zohobooks/streams.py
+++ b/tap_zohobooks/streams.py
@@ -1309,7 +1309,9 @@ class SalesOrdersStream(ZohoBooksStream):
                 params=params,
                 headers=self.authenticator.auth_headers
             )
-            detail_response = self._request(req.prepare(), timeout=self.timeout)
+            prepared_request = req.prepare()
+            prepared_request.timeout = self.timeout
+            detail_response = self._request(prepared_request)
 
             sales_details = extract_jsonpath(self.records_jsonpath, input=detail_response.json())
 

--- a/tap_zohobooks/streams.py
+++ b/tap_zohobooks/streams.py
@@ -1309,7 +1309,7 @@ class SalesOrdersStream(ZohoBooksStream):
                 params=params,
                 headers=self.authenticator.auth_headers
             )
-            detail_response = self._request(req.prepare())
+            detail_response = self._request(req.prepare(), timeout=self.timeout)
 
             sales_details = extract_jsonpath(self.records_jsonpath, input=detail_response.json())
 

--- a/tap_zohobooks/streams.py
+++ b/tap_zohobooks/streams.py
@@ -1309,9 +1309,7 @@ class SalesOrdersStream(ZohoBooksStream):
                 params=params,
                 headers=self.authenticator.auth_headers
             )
-            prepared_request = req.prepare()
-            prepared_request.timeout = self.timeout
-            detail_response = self._request(prepared_request)
+            detail_response = self._request(req.prepare(), timeout=self.timeout)
 
             sales_details = extract_jsonpath(self.records_jsonpath, input=detail_response.json())
 


### PR DESCRIPTION
The sales orders details request has no timeout, causing the tap to hang indefinitely when Zoho API is slow or unresponsive.
Added timeout parameter using the preconfigured \`self.timeout\` value from the base class.